### PR TITLE
set_chaddr: Fix the hardware setting

### DIFF
--- a/src/v4/mod.rs
+++ b/src/v4/mod.rs
@@ -282,7 +282,11 @@ impl Message {
     /// Set the message's hops.
     pub fn set_chaddr(&mut self, chaddr: &[u8]) -> &mut Self {
         let mut new_chaddr = [0; 16];
-        new_chaddr.copy_from_slice(chaddr);
+        if chaddr.len() >= 16 {
+            new_chaddr.copy_from_slice(&chaddr[..16]);
+        } else {
+            new_chaddr[..chaddr.len()].copy_from_slice(chaddr);
+        }
         self.hlen = chaddr.len() as u8;
         self.chaddr = new_chaddr;
         self


### PR DESCRIPTION
Current `set_chaddr()` function expects a `[u8;16]` slice due to
requirement of `copy_from_slice()`. This cause the `hlen` been always
set to 16.

This patch fix it by allowing variable length of input u8 slice and set
`hlen` accordingly.

Tested in my person project with dnsmasq:
 * Before:
   `DHCPREQUEST(eth1.ep) 192.0.2.32`
   `12:a9:63:e8:f0:b8:00:00:00:00:00:00:00:00:00:00`

 * After:
   `DHCPREQUEST(eth1.ep) 192.0.2.32 12:a9:63:e8:f0:b8`